### PR TITLE
Default to 'no schema' in the configuration

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -78,6 +78,7 @@ module.exports = (function () {
     
     // Default configuration for connections
     defaults: {
+      schema: false,
       host: 'localhost',
       port: 8529,
       username: '',


### PR DESCRIPTION
When I tried the adapter, I noticed that it doesn't save the provided attributes for the documents. This line will fix it :smile: 

This fixes the bug that no data apart from the timestamps are saved when creating documents.
