### PR TITLE
made serverUrl higher scope so ensureDB can have the same basic auth in url…

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -8,6 +8,7 @@ module.exports = (function() {
 
   'use strict';
 
+  var serverUrl = '';
   var defaults = {
     createCustomIndex: false,
     idProperty: 'id'
@@ -31,7 +32,7 @@ module.exports = (function() {
       userpassword = connection.user + ':' + connection.password + '@'
     }
 
-    var serverUrl = 'http://' + userpassword + connection.host + ':' + connection.port;
+    serverUrl = 'http://' + userpassword + connection.host + ':' + connection.port;
     if (!server) {
       server = new Arango({
         url: serverUrl,
@@ -51,7 +52,7 @@ module.exports = (function() {
 
   DbHelper.logError = function(err) {
     console.error(err.stack);
-  }
+  };
 
   DbHelper.prototype.db = null;
   DbHelper.prototype.collections = null;
@@ -76,7 +77,10 @@ module.exports = (function() {
 
     async.auto({
         ensureDB: function(next) {
-          var system_db = Arango();
+          var system_db = Arango({
+            url: serverUrl,
+            databaseName: '_system'
+          });
           system_db.listDatabases(function(err, dbs) {
             if (err) {
               DbHelper.logError(err);


### PR DESCRIPTION
… when passed.

Let me know if you have another way to do this rather then making serverUrl go up in Scope....  the ensureDb function was the reason why it was coming back unAuthorized....if you set the server to be authenticated... it will deny the Arango() call because no serverUrl with the credentials in the url is passed.
