### PR TITLE
Fix compatibility due to arangojs 5.0.x release

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "arangojs": ">=4.0.1",
+    "arangojs": "4.x.x",
     "q": "^1.0.1",
     "underscore": "^1.6.0",
     "lodash": ">=3.10.1",


### PR DESCRIPTION
Couple of days ago a new `arangojs` package v.5.0.0 was [released](https://github.com/arangodb/arangojs/releases/tag/v5.0.0) introducing backward incompatibility with 4.x branch.

In order to make current driver code working I have modified `package.json` file to use `arangosj` from 4.x branch.

Please integrate changes to master branch till the moment when `sails-arangodb` will be modified to work with latest v.5.x branch of `arangojs`.
